### PR TITLE
ensure phasOnlyOneTokenOfCurrencySymbol behaves

### DIFF
--- a/liqwid-plutarch-extra/CHANGELOG.md
+++ b/liqwid-plutarch-extra/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.21.0 -- 2023-01-17
+
+### Modified 
+
+- 'Plutarch.Extra.Value': 'phasOnlyOneTokenOfCurrencySymbol' now correctly
+  disallows negative tokens when ensuring presence of only one token.
+
 ## 3.20.2 -- 2022-12-10
 
 ### Modified

--- a/liqwid-plutarch-extra/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra/liqwid-plutarch-extra.cabal
@@ -173,6 +173,7 @@ test-suite test
     NumericProp
     OrdProp
     TraversableProp
+    ValueProp
 
   build-depends:
     , liqwid-plutarch-extra

--- a/liqwid-plutarch-extra/src/Plutarch/Extra/Value.hs
+++ b/liqwid-plutarch-extra/src/Plutarch/Extra/Value.hs
@@ -568,21 +568,23 @@ type family AddGuarantees (a :: AmountGuarantees) (b :: AmountGuarantees) where
   AddGuarantees _ _ = 'NoGuarantees
 
 {- | Returns 'PTrue' if the entire argument 'PValue' contains /exactly/ one
- token of the argument 'PCurrencySymbol' (and contains no other assets).
+     token of the argument 'PCurrencySymbol' (and contains no other assets).
 
- @since 1.3.0
+     @since 3.21.0
 -}
 phasOnlyOneTokenOfCurrencySymbol ::
   forall (keys :: KeyGuarantees) (amounts :: AmountGuarantees) (s :: S).
   Term s (PCurrencySymbol :--> PValue keys amounts :--> PBool)
 phasOnlyOneTokenOfCurrencySymbol = phoistAcyclic $
   plam $ \cs vs ->
-    psymbolValueOf
-      # cs
-      # vs
-      #== 1
-      #&& (plength #$ pto $ pto $ pto vs)
-      #== 1
+    pmatch
+      ( psymbolValueOf'
+          # cs
+          # vs
+      )
+      $ \case
+        PNothing -> pcon PFalse
+        PJust r -> r #== pcon (PPair 1 0) #&& (plength #$ pto $ pto $ pto vs) #== 1
 
 {- | Returns 'PTrue' if the argument 'PValue' contains /exactly/
   one token of the argument 'PAssetClass'.

--- a/liqwid-plutarch-extra/src/Plutarch/Extra/Value.hs
+++ b/liqwid-plutarch-extra/src/Plutarch/Extra/Value.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Plutarch.Extra.Value (
   -- * Creation
@@ -56,6 +57,7 @@ import Plutarch.Api.V1 (
  )
 import Plutarch.Api.V1.AssocMap (plookup)
 import Plutarch.Api.V1.AssocMap qualified as AssocMap
+import Plutarch.Api.V1.Value (padaSymbol)
 import Plutarch.Api.V1.Value qualified as Value
 import Plutarch.Api.V2 (
   AmountGuarantees (NoGuarantees, Positive),
@@ -71,7 +73,8 @@ import Plutarch.Extra.AssetClass (
  )
 import Plutarch.Extra.Comonad (pextract)
 import Plutarch.Extra.Functor (PFunctor (pfmap))
-import Plutarch.Extra.List (pfromList, plookupAssoc, ptryElimSingle)
+import Plutarch.Extra.IsData (PlutusTypeEnumData)
+import Plutarch.Extra.List (pfromList, pfromSingleton, plookupAssoc, ptryElimSingle, ptryFromSingleton)
 import Plutarch.Extra.Map (phandleMin)
 import Plutarch.Extra.Maybe (pexpectJustC)
 import Plutarch.Extra.Ord (PComparator, pfromOrdBy)
@@ -568,24 +571,124 @@ type family AddGuarantees (a :: AmountGuarantees) (b :: AmountGuarantees) where
   AddGuarantees 'Positive 'Positive = 'Positive
   AddGuarantees _ _ = 'NoGuarantees
 
+-- Used internally only in 'phasOnlyOneTokenOfCurrencySymbol'
+data PState (s :: S)
+  = PInitial
+  | PFound
+  | PFailed
+  deriving stock
+    ( Generic
+    , Enum
+    , Bounded
+    )
+  deriving anyclass
+    ( PlutusType
+    )
+
+instance DerivePlutusType PState where
+  type DPTStrat _ = PlutusTypeEnumData
+
 {- | Returns 'PTrue' if the entire argument 'PValue' contains /exactly/ one
      token of the argument 'PCurrencySymbol' (and contains no other assets).
+
+     This implementation makes a special case for ADA, where it allows
+     zero-ada entries in the given 'PValue'.
 
      @since 3.21.0
 -}
 phasOnlyOneTokenOfCurrencySymbol ::
-  forall (keys :: KeyGuarantees) (amounts :: AmountGuarantees) (s :: S).
-  Term s (PCurrencySymbol :--> PValue keys amounts :--> PBool)
-phasOnlyOneTokenOfCurrencySymbol = phoistAcyclic $
-  plam $ \cs vs ->
-    pmatch
-      ( psymbolValueOf'
-          # cs
-          # vs
-      )
-      $ \case
-        PNothing -> pcon PFalse
-        PJust r -> r #== pcon (PPair 1 0) #&& (pcountNonZeroes # vs) #== 1
+  forall (kg :: KeyGuarantees) (ag :: AmountGuarantees) (s :: S).
+  Term s (PCurrencySymbol :--> PValue kg ag :--> PBool)
+phasOnlyOneTokenOfCurrencySymbol =
+  {- Implementation notes:
+
+      This is implemented using a state machine with three states: 'PInitial', 'PFound', 'PFailed'.
+
+      See this comment for the state transition graph:
+      https://gist.github.com/chfanghr/c3ef2f0ed1561e7b17dd11c1df609479?permalink_comment_id=4443620#gistcomment-4443620
+
+      This implementation makes a special case for ADA, where it allows zero-ada entries in the 'PValue'.
+  -}
+  plam $
+    \cs
+     ( (pto . pto) ->
+        l
+      ) ->
+        let isZeroAdaEntry ::
+              Term
+                s
+                ( PBuiltinPair (PAsData PCurrencySymbol) (PAsData (PMap kg PTokenName PInteger))
+                    :--> PBool
+                )
+            isZeroAdaEntry = plam $ \pair ->
+              let cs' = pfromData $ pfstBuiltin # pair
+                  isAda = ptraceIfFalse "Not ada" $ cs' #== padaSymbol
+
+                  tnMap = pfromData $ psndBuiltin # pair
+                  count = pfromData $ psndBuiltin # (ptryFromSingleton # pto tnMap)
+                  zeroAda = ptraceIfFalse "Non zero ada" $ count #== 0
+               in isAda #&& zeroAda
+
+            isNonAdaEntrValid ::
+              Term
+                s
+                ( PBuiltinPair (PAsData PCurrencySymbol) (PAsData (PMap kg PTokenName PInteger))
+                    :--> PBool
+                )
+            isNonAdaEntrValid = plam $ \pair ->
+              let cs' = pfromData $ pfstBuiltin # pair
+                  validCs = ptraceIfFalse "Unknown symbol" $ cs' #== cs
+
+                  tnMap = pfromData $ psndBuiltin # pair
+                  validTnMap = ptraceIfFalse "More than one token names or tokens" $
+                    pmatch (pfromSingleton # pto tnMap) $ \case
+                      PNothing -> pcon PFalse
+                      PJust ((pfromData . (psndBuiltin #)) -> tokenCount) ->
+                        tokenCount #== 1
+               in validCs #&& validTnMap
+
+            go ::
+              Term
+                (s :: S)
+                ( ( PState
+                      :--> PBuiltinList
+                            ( PBuiltinPair
+                                (PAsData PCurrencySymbol)
+                                (PAsData (PMap kg PTokenName PInteger))
+                            )
+                      :--> PState
+                  )
+                    :--> PState
+                    :--> PBuiltinList
+                          ( PBuiltinPair
+                              (PAsData PCurrencySymbol)
+                              (PAsData (PMap kg PTokenName PInteger))
+                          )
+                    :--> PState
+                )
+            go = plam $ \self lastState ->
+              pelimList
+                ( \x xs -> pif
+                    (isZeroAdaEntry # x)
+                    (self # lastState # xs)
+                    $ pmatch lastState
+                    $ \case
+                      PInitial ->
+                        pif
+                          (isNonAdaEntrValid # x)
+                          (self # pcon PFound # xs)
+                          (pcon PFailed)
+                      PFound -> pcon PFailed
+                      PFailed -> ptraceError "unreachable"
+                )
+                ( pmatch lastState $ \case
+                    PFound -> lastState
+                    _ -> pcon PFailed
+                )
+         in pmatch (pfix # go # pcon PInitial # l) $
+              \case
+                PFound -> pcon PTrue
+                _ -> pcon PFalse
 
 {- | Returns the count of non-zero currency symbols in a 'PValue'.
 

--- a/liqwid-plutarch-extra/test/Main.hs
+++ b/liqwid-plutarch-extra/test/Main.hs
@@ -9,6 +9,7 @@ import FunctorProp qualified
 import NumericProp qualified
 import OrdProp qualified
 import TraversableProp qualified
+import ValueProp qualified
 
 main :: IO ()
 main = do
@@ -18,4 +19,5 @@ main = do
     , NumericProp.tests
     , TraversableProp.tests
     , FunctorProp.tests
+    , ValueProp.tests
     ]

--- a/liqwid-plutarch-extra/test/ValueProp.hs
+++ b/liqwid-plutarch-extra/test/ValueProp.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE PackageImports #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+
+module ValueProp (tests) where
+
+import Data.Maybe (catMaybes)
+import Plutarch.Api.V2 (PMap (PMap))
+import Plutarch.Builtin (ppairDataBuiltin)
+import "liqwid-plutarch-extra" Plutarch.Extra.List (pfromList)
+import Plutarch.Extra.Value (phasOnlyOneTokenOfCurrencySymbol, pvalue)
+import Plutarch.Test.QuickCheck (fromPFun)
+import Test.QuickCheck (
+  Property,
+  arbitrary,
+  forAllShrinkShow,
+  shrink,
+ )
+import Test.Tasty (TestTree, adjustOption, testGroup)
+import Test.Tasty.QuickCheck (QuickCheckTests, testProperty)
+
+tests :: TestTree
+tests =
+  adjustOption go $
+    testGroup
+      "Value"
+      [ testProperty "phasOnlyOneTokenOfCurrencySymbol" propOnlyOneToken
+      ]
+  where
+    go :: QuickCheckTests -> QuickCheckTests
+    go = max 5000
+
+propOnlyOneToken :: Property
+propOnlyOneToken =
+  let buildScenario (targetSym, targetToken, targetAmount) maybeAdaAmount aux =
+        pfromData
+          $ pvalue
+            #$ pfromList
+          $ catMaybes
+            [ Just $
+                ppairDataBuiltin
+                  # pdata targetSym
+                  # pdata
+                    ( pcon . PMap $
+                        pfromList
+                          [ ppairDataBuiltin # pdata targetToken # pdata targetAmount
+                          ]
+                    )
+            , fmap
+                ( \adaAmount ->
+                    ppairDataBuiltin
+                      # pconstantData ""
+                      # pdata
+                        ( pcon . PMap $
+                            pfromList
+                              [ ppairDataBuiltin # (pconstantData "") # pdata adaAmount
+                              ]
+                        )
+                )
+                maybeAdaAmount
+            , fmap
+                ( \(auxSym, auxToken, auxAmount) ->
+                    ppairDataBuiltin
+                      # pdata auxSym
+                      # pdata
+                        ( pcon . PMap $
+                            pfromList
+                              [ ppairDataBuiltin # pdata auxToken # pdata auxAmount
+                              ]
+                        )
+                )
+                aux
+            ]
+   in forAllShrinkShow arbitrary shrink show $
+        fromPFun $
+          plam $ \targetSym targetToken targetAmount adaAmount auxSym auxToken auxAmount ->
+            foldr
+              (#&&)
+              (pcon PTrue)
+              [ pnot #$ phasOnlyOneTokenOfCurrencySymbol # targetSym # (pfromData $ pvalue # pconstant [])
+              , (targetAmount #== 1)
+                  #== ( phasOnlyOneTokenOfCurrencySymbol
+                          # targetSym
+                          # buildScenario (targetSym, targetToken, targetAmount) Nothing Nothing
+                      )
+              , pif (targetSym #== pconstant "") (pcon PTrue) $
+                  ((targetAmount #== 1 #&& adaAmount #== 0))
+                    #== ( phasOnlyOneTokenOfCurrencySymbol
+                            # targetSym
+                            # buildScenario (targetSym, targetToken, targetAmount) (Just adaAmount) Nothing
+                        )
+              , pif (targetSym #== pconstant "" #|| auxSym #== pconstant "") (pcon PTrue) $
+                  pnot
+                    # ( phasOnlyOneTokenOfCurrencySymbol
+                          # targetSym
+                          # buildScenario (targetSym, targetToken, targetAmount) (Just adaAmount) (Just (auxSym, auxToken, auxAmount))
+                      )
+              ]


### PR DESCRIPTION
In the case of having a value structures as follows:

`[(s, [(a, 2), (b, -1)])]`, where `s` is a symbol and `a` and `b` are
token names, previously `phasOnlyOneTokenOfCurrencySymbol` would return
`PTrue`. This is incorrect, because the value contains multiple tokens.

Now, using `psymbolValueOf'`, we require that the value be _strictly_
positive, as well as being a single token.

Thanks @colll78!
