### PR TITLE
Remove ptrace usage in LPE

### DIFF
--- a/liqwid-plutarch-extra/CHANGELOG.md
+++ b/liqwid-plutarch-extra/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.21.1 -- 2023-01-30
+
+### Removed
+
+- All use of `ptrace` (or variants); this is a temporary work-around to script size
+  inflation.
+
 ## 3.21.0 -- 2023-01-27
 
 ### Modified 

--- a/liqwid-plutarch-extra/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.21.0
+version:            3.21.1
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra

--- a/liqwid-plutarch-extra/src/Plutarch/Extra/Bool.hs
+++ b/liqwid-plutarch-extra/src/Plutarch/Extra/Bool.hs
@@ -42,10 +42,10 @@ pcompare t1 t2 ifLT ifEQ ifGT =
 pcond :: forall (s :: S) (a :: S -> Type). [Term s a -> Term s a] -> Term s a -> Term s a
 pcond = appEndo . foldMap Endo
 
-{- | If the condition evaluated to true, return the third argument. Otherwise error
-     out with the error message.
+{- | If the condition evaluates to 'PTrue', return the third argument;
+ otherwise, error out.
 
-     @since 3.14.1
+ @since 3.21.1
 -}
 passert ::
   forall (a :: PType) (s :: S).
@@ -56,4 +56,4 @@ passert ::
   -- | The result.
   Term s a ->
   Term s a
-passert msg cond x = pif cond x $ ptraceError msg
+passert _ cond x = pif cond x perror -- ptraceError msg

--- a/liqwid-plutarch-extra/src/Plutarch/Extra/List.hs
+++ b/liqwid-plutarch-extra/src/Plutarch/Extra/List.hs
@@ -66,17 +66,19 @@ ptryElimSingle ::
   (Term s a -> Term s r) ->
   Term s (ell a) ->
   Term s r
-ptryElimSingle f = pelimList go (ptraceError emptyErr)
+ptryElimSingle f = pelimList go perror -- (ptraceError emptyErr)
   where
     go ::
       Term s a ->
       Term s (ell a) ->
       Term s r
-    go h t = pif (pnull # t) (f h) (ptraceError nonSingleErr)
+    go h t = pif (pnull # t) (f h) perror -- (ptraceError nonSingleErr)
+    {-
     emptyErr :: Term s PString
     emptyErr = "ptryElimSingle: Found empty list-like."
     nonSingleErr :: Term s PString
     nonSingleErr = "ptryElimSingle: Found non-singleton list-like."
+    -}
 
 {- | Similar to 'pmap', but allows elements to be thrown out. More precisely,
  for elements where the function argument returns 'PNothing', the
@@ -304,7 +306,9 @@ ptryDeleteFirstBy = phoistAcyclic $
             t
             (pcons # h #$ self # t)
       )
-      (const $ ptraceError "Cannot delete element")
+      (const $ perror)
+
+-- (const $ ptraceError "Cannot delete element")
 
 {- | Special version of 'pdeleteBy', for types with 'PEq' instance.
 
@@ -377,6 +381,9 @@ ptryFromSingleton =
           pif
             (pnull # t)
             h
-            (ptraceError "More than one element")
+            perror
+            -- (ptraceError "More than one element")
       )
-      (const $ ptraceError "Empty list")
+      (const $ perror)
+
+-- (const $ ptraceError "Empty list")

--- a/liqwid-plutarch-extra/src/Plutarch/Extra/Ord.hs
+++ b/liqwid-plutarch-extra/src/Plutarch/Extra/Ord.hs
@@ -93,7 +93,9 @@ import Plutarch.Api.V1.Value (
 import Plutarch.Bool (pif')
 import Plutarch.Extra.List (phandleList, precListLookahead)
 import Plutarch.Extra.Map (phandleMin)
-import Plutarch.Extra.Maybe (ptraceIfNothing)
+import Plutarch.Maybe (pfromJust)
+
+-- import Plutarch.Extra.Maybe (ptraceIfNothing)
 import Plutarch.Internal.PlutusType (PlutusType (pcon', pmatch'))
 import Plutarch.Lift (
   PConstantDecl (
@@ -611,8 +613,10 @@ ptryAllUniqueBy ::
   (PElemConstraint ell a, PListLike ell) =>
   Term s (PComparator a :--> ell a :--> PBool)
 ptryAllUniqueBy = phoistAcyclic $
-  plam $ \cmp xs ->
-    ptraceIfNothing "ptryAllUniqueBy: argument is unordered" $ pallUniqueBy # cmp # xs
+  plam $
+    \cmp xs -> pfromJust #$ pallUniqueBy # cmp # xs
+
+-- ptraceIfNothing "ptryAllUniqueBy: argument is unordered" $ pallUniqueBy # cmp # xs
 
 {- | Merge two list-like structures, whose contents are sorted by the 'POrd'
  instance for their contents, into one sorted list-like structure. This will
@@ -1001,7 +1005,11 @@ passertSortedLookahead = phoistAcyclic $
       unorderedError
 
 unorderedError :: forall (a :: S -> Type) (s :: S). Term s a
+unorderedError = perror
+
+{-
 unorderedError = ptraceError "ptryMergeBy: argument list-like out of order"
+-}
 
 -- Helper for dragging a comparator through a map. We hide this away to ensure
 -- that people actually use the comparator as intended.
@@ -1116,7 +1124,8 @@ pinsertUniqueBy = phoistAcyclic $
               let ensureUniqueness =
                     pif
                       (eq # x # h)
-                      (ptraceError "inserted value already exists")
+                      perror
+                  -- (ptraceError "inserted value already exists")
                   next =
                     pif
                       (lt # x # h)

--- a/liqwid-plutarch-extra/src/Plutarch/Extra/Rational.hs
+++ b/liqwid-plutarch-extra/src/Plutarch/Extra/Rational.hs
@@ -256,7 +256,7 @@ ptoPositiveCases n contNeg contPos =
     (n #<= 0)
     ( pif
         (n #== 0)
-        (ptraceError "ptoPositiveCases with 0")
+        perror -- (ptraceError "ptoPositiveCases with 0")
         -- The PPositive constructor is not exported, so we need coercion
         (contNeg (punsafeCoerce $ -n))
     )

--- a/liqwid-plutarch-extra/src/Plutarch/Extra/StateThread.hs
+++ b/liqwid-plutarch-extra/src/Plutarch/Extra/StateThread.hs
@@ -101,10 +101,12 @@ withStateThreadGeneric checkMint mp ref = plam $ \red ctx -> pletAll ctx $ \ctx'
           ( pif
               (pany # (hasUniqueInput # ref) # getField @"inputs" txInfo)
               (mp # red # ctx)
-              (ptraceError "stateThread: Unique input not found")
+              perror
+              -- (ptraceError "stateThread: Unique input not found")
           )
-          (ptraceError "stateThread: Not minting a unique state token")
-      _ -> ptraceError "stateThread: Not a minting script purpose"
+          perror
+      -- (ptraceError "stateThread: Not minting a unique state token")
+      _ -> perror -- ptraceError "stateThread: Not a minting script purpose"
 
 uniqueStateTokenMint ::
   forall (keys :: KeyGuarantees) (amounts :: AmountGuarantees) (s :: S).

--- a/liqwid-plutarch-extra/src/Plutarch/Extra/Time.hs
+++ b/liqwid-plutarch-extra/src/Plutarch/Extra/Time.hs
@@ -82,12 +82,14 @@ pgetFullyBoundedTimeRange = phoistAcyclic $
                 (getField @"_1" f)
                 ( pmatch (getField @"_0" f) $ \case
                     PFinite (pfromData . (pfield @"_0" #) -> d) -> pjust # d
-                    _ ->
+                    _ -> pnothing
+                    {-
                       ptrace
                         "pcurrentTime: time range should be bounded"
-                        pnothing
+                        pnothing -}
                 )
-                (ptrace "pcurrentTime: time range should be inclusive" pnothing)
+                pnothing
+        -- (ptrace "pcurrentTime: time range should be inclusive" pnothing)
 
         lb' = getBound # lb
         ub' = getBound # ub

--- a/liqwid-plutarch-extra/src/Plutarch/Extra/Value.hs
+++ b/liqwid-plutarch-extra/src/Plutarch/Extra/Value.hs
@@ -99,7 +99,7 @@ passetClassDataValue = phoistAcyclic $
   plam $ \ac i ->
     pif
       (i #== 0)
-      (ptraceError "passetClassDataValue: given zero argument, expecting nonzero.")
+      perror -- (ptraceError "passetClassDataValue: given zero argument, expecting nonzero.")
       ( let cs = pfield @"symbol" # ac
             tn = pfield @"name" # ac
          in Value.psingleton # pfromData cs # pfromData tn # i
@@ -622,11 +622,10 @@ phasOnlyOneTokenOfCurrencySymbol =
                 )
             isZeroAdaEntry = plam $ \pair ->
               let cs' = pfromData $ pfstBuiltin # pair
-                  isAda = ptraceIfFalse "Not ada" $ cs' #== padaSymbol
-
+                  isAda = cs' #== padaSymbol -- ptraceIfFalse "Not ada" $ cs' #== padaSymbol
                   tnMap = pfromData $ psndBuiltin # pair
                   count = pfromData $ psndBuiltin # (ptryFromSingleton # pto tnMap)
-                  zeroAda = ptraceIfFalse "Non zero ada" $ count #== 0
+                  zeroAda = count #== 0 -- ptraceIfFalse "Non zero ada" $ count #== 0
                in isAda #&& zeroAda
 
             isNonAdaEntryValid ::
@@ -637,15 +636,19 @@ phasOnlyOneTokenOfCurrencySymbol =
                 )
             isNonAdaEntryValid = plam $ \pair ->
               let cs' = pfromData $ pfstBuiltin # pair
-                  validCs = ptraceIfFalse "Unknown symbol" $ cs' #== cs
-
+                  validCs = cs' #== cs -- ptraceIfFalse "Unknown symbol" $ cs' #== cs
                   tnMap = pfromData $ psndBuiltin # pair
+                  validTnMap = pmatch (pfromSingleton # pto tnMap) $ \case
+                    PNothing -> pcon PFalse
+                    PJust ((pfromData . (psndBuiltin #)) -> tokenCount) ->
+                      tokenCount #== 1
+               in {-
                   validTnMap = ptraceIfFalse "More than one token names or tokens" $
                     pmatch (pfromSingleton # pto tnMap) $ \case
                       PNothing -> pcon PFalse
                       PJust ((pfromData . (psndBuiltin #)) -> tokenCount) ->
-                        tokenCount #== 1
-               in validCs #&& validTnMap
+                        tokenCount #== 1 -}
+                  validCs #&& validTnMap
 
             go ::
               Term
@@ -680,7 +683,7 @@ phasOnlyOneTokenOfCurrencySymbol =
                             (self # pcon PFound # xs)
                             (pcon PFailed)
                         PFound -> pcon PFailed
-                        PFailed -> ptraceError "unreachable"
+                        PFailed -> perror -- ptraceError "unreachable"
                   )
                   ( pmatch lastState $ \case
                       PFound -> lastState
@@ -794,7 +797,7 @@ findValue sym tk self x xs = plet x $ \pair ->
       pif
         (pfstBuiltin # kv #== tk)
         (pfromData $ psndBuiltin # kv)
-        (ptraceError "findValue: Unexpectedly missing result.")
+        perror -- (ptraceError "findValue: Unexpectedly missing result.")
 
 unsafeMatchValueAssetsInternal ::
   forall (k :: KeyGuarantees) (s :: S).

--- a/liqwid-plutarch-extra/src/Plutarch/Orphans.hs
+++ b/liqwid-plutarch-extra/src/Plutarch/Orphans.hs
@@ -84,7 +84,7 @@ instance PTryFrom PData (PAsData PDatumHash) where
         -- Blake2b_256 hash: 256 bits/32 bytes.
         (plengthBS # unwrapped #== 32)
         (f ())
-        (ptraceError "ptryFrom(PDatumHash): must be 32 bytes long")
+        perror -- (ptraceError "ptryFrom(PDatumHash): must be 32 bytes long")
     pure (punsafeCoerce opq, pcon $ PDatumHash unwrapped)
 
 -- | @since 3.0.3


### PR DESCRIPTION
This (temporarily) culls all usage of `ptrace` (and related functions) from LPE, without changing any APIs.