### PR TITLE
Deprecate pguardShowC

### DIFF
--- a/liqwid-plutarch-extra/CHANGELOG.md
+++ b/liqwid-plutarch-extra/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.21.1 -- 2023-01-27
+
+### Modified
+
+- `pguardShowC` is deprecated, due to its on-chain impact for size.
+
 ## 3.21.0 -- 2023-01-27
 
 ### Modified 

--- a/liqwid-plutarch-extra/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.21.0
+version:            3.21.1
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra

--- a/liqwid-plutarch-extra/src/Plutarch/Extra/TermCont.hs
+++ b/liqwid-plutarch-extra/src/Plutarch/Extra/TermCont.hs
@@ -49,6 +49,7 @@ pguardWithC tracer checker object =
 
   @since 1.1.0
 -}
+{-# DEPRECATED pguardShowC "This is very heavy on-chain." #-}
 pguardShowC ::
   forall (r :: S -> Type) (pt :: S -> Type) (s :: S).
   PShow pt =>


### PR DESCRIPTION
Supercedes #8. As `pguardShowC` uses a combination of `ptrace` and `pshow`, it has very heavy on-chain costs, and thus, shouldn't be used. To minimize breakage, we only deprecate, rather than outright remove, this function, but we should remove it on the next major release of LPE.