### PR TITLE
Fix `fullyBoundedTimeRangeFromValidRange` always returns Nothing

### DIFF
--- a/liqwid-plutarch-extra/CHANGELOG.md
+++ b/liqwid-plutarch-extra/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.21.2 -- 2023-02-15
+
+### Fixed
+
+- Fix `pgetFullyBoundedTimeRange` always returns nothing
+
 ## 3.21.1 -- 2023-01-27
 
 ### Modified

--- a/liqwid-plutarch-extra/src/Plutarch/Extra/Time.hs
+++ b/liqwid-plutarch-extra/src/Plutarch/Extra/Time.hs
@@ -76,10 +76,10 @@ pgetFullyBoundedTimeRange = phoistAcyclic $
     PUpperBound ub <- pmatchC (getField @"to" ivf)
 
     let getBound = phoistAcyclic $
-          plam $
+          plam $ \dontCheckInclusive ->
             flip pletAll $ \f ->
               pif
-                (getField @"_1" f)
+                (dontCheckInclusive #|| getField @"_1" f)
                 ( pmatch (getField @"_0" f) $ \case
                     PFinite (pfromData . (pfield @"_0" #) -> d) -> pjust # d
                     _ ->
@@ -89,8 +89,8 @@ pgetFullyBoundedTimeRange = phoistAcyclic $
                 )
                 (ptrace "pcurrentTime: time range should be inclusive" pnothing)
 
-        lb' = getBound # lb
-        ub' = getBound # ub
+        lb' = getBound # pcon PFalse # lb
+        ub' = getBound # pcon PTrue # ub
 
         mkTime = phoistAcyclic $ plam $ pcon .* PFullyBoundedTimeRange
     pure $ pliftA2 # mkTime # lb' # ub'


### PR DESCRIPTION
The upper bound of the `validRange` is always open, see the discussion in this issue: https://github.com/Plutonomicon/cardano-transaction-lib/issues/1041