### PR TITLE
bump liqwid-nix to 2.7.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1016,11 +1016,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1677714448,
-        "narHash": "sha256-Hq8qLs8xFu28aDjytfxjdC96bZ6pds21Yy09mSC156I=",
+        "lastModified": 1678379998,
+        "narHash": "sha256-TZdfNqftHhDuIFwBcN9MUThx5sQXCTeZk9je5byPKRw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "dc531e3a9ce757041e1afaff8ee932725ca60002",
+        "rev": "c13d60b89adea3dc20704c045ec4d50dd964d447",
         "type": "github"
       },
       "original": {
@@ -2168,16 +2168,16 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1678976743,
-        "narHash": "sha256-BCRqiIqvNfF7KerCiZXJEr93IfhVIl5yQzm+wWg6fyU=",
+        "lastModified": 1679506613,
+        "narHash": "sha256-Vwv85+Z4WPbodqsubMLgg4WiW+2z30Zt6Q8rPY9WT8o=",
         "owner": "liqwid-labs",
         "repo": "liqwid-nix",
-        "rev": "c9b5cff60490f1ea992f0bd7886d700e1beeb897",
+        "rev": "c763f911371def8c96a3191e5a1e549d4b501ee0",
         "type": "github"
       },
       "original": {
         "owner": "liqwid-labs",
-        "ref": "v2.7.0",
+        "ref": "v2.7.2",
         "repo": "liqwid-nix",
         "type": "github"
       }
@@ -3309,11 +3309,11 @@
     "nixpkgs-lib_2": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1677407201,
-        "narHash": "sha256-3blwdI9o1BAprkvlByHvtEm5HAIRn/XPjtcfiunpY7s=",
+        "lastModified": 1678375444,
+        "narHash": "sha256-XIgHfGvjFvZQ8hrkfocanCDxMefc/77rXeHvYdzBMc8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7f5639fa3b68054ca0b062866dc62b22c3f11505",
+        "rev": "130fa0baaa2b93ec45523fdcde942f6844ee9f6e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
     nixpkgs-latest.url = "github:NixOS/nixpkgs?rev=a2494bf2042d605ca1c4a679401bdc4971da54fb";
 
     liqwid-nix = {
-      url = "github:liqwid-labs/liqwid-nix/v2.7.0";
+      url = "github:liqwid-labs/liqwid-nix/v2.7.2";
       inputs.nixpkgs-latest.follows = "nixpkgs-latest";
     };
 


### PR DESCRIPTION
Most importantly, this means hercules builds only build on x86_64-linux.